### PR TITLE
Add support for Simplified Chinese and Traditional Chinese

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -184,6 +184,28 @@ constexpr config_strings get_config_strings(nn::swkbd::LanguageType language) {
                     .restart_to_apply_action = "Neustarten zum Anwenden",
                     .need_menu_action = "Nur vom Wii U-Menü aus",
             };
+        case nn::swkbd::LanguageType::Simplified_Chinese:
+            return {
+                .plugin_name = "Inkay",
+                .network_category = "选择网络",
+                .connect_to_network_setting = "连接到Pretendo network",
+                .other_category = "其他设置",
+                .reset_wwp_setting = "重置Wara Wara Plaza",
+                .press_a_action = "请按 A",
+                .restart_to_apply_action = "重启以应用设置",
+                .need_menu_action = "仅来自WiiU Menu"
+            };
+        case nn::swkbd::LanguageType::traditional_Chinese:
+            return {
+                .plugin_name = "Inkay",
+                .network_category = "選擇網路",
+                .connect_to_network_setting = "連接到Pretendo network",
+                .other_category = "其他設定",
+                .reset_wwp_setting = "重置Wara Wara Plaza",
+                .press_a_action = "請按 A",
+                .restart_to_apply_action = "重啓以套用設定",
+                .need_menu_action = "僅來自WiiU Menu"
+            };
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,6 +111,10 @@ static const char * get_nintendo_network_message() {
             return "Usando Nintendo Network";
         case nn::swkbd::LanguageType::German:
             return "Nutze Nintendo Network";
+        case nn::swkbd::LanguageType::Simplified_Chinese:
+            return "使用 Nintendo Network";
+        case nn::swkbd::LanguageType::traditional_Chinese:
+            return "使用 Nintendo Network";
     }
 }
 static const char * get_pretendo_message() {
@@ -129,6 +133,10 @@ static const char * get_pretendo_message() {
             return "Usando Pretendo Network";
         case nn::swkbd::LanguageType::German:
             return "Nutze Pretendo Network";
+        case nn::swkbd::LanguageType::Simplified_Chinese:
+            return "使用 Pretendo Network";
+        case nn::swkbd::LanguageType::traditional_Chinese:
+            return "使用 Pretendo Network";
     }
 }
 


### PR DESCRIPTION
Add support for Simplified Chinese and Traditional Chinese.
However, wiiu did not set options for these two languages.
And it may need to call the Chinese font library of wiiu.
If the plugin is unable to call the font library, it is necessary to retrieve `OSGetSharedData (OS_SHAREDDATATYPE FONT-STANDARD, 0,&font,&size) ` from line 208 of WiiUPluginLoaderBackend Change to `OSGetSharedData (OS-SHAREDDATATYPE FONT-CHINESE, 0,&font,&size);`

https://github.com/wiiu-env/WiiUPluginLoaderBackend/blob/baee1afda35d4be830ea09a6c38a0ec7e6d7c30b/source/utils/DrawUtils.cpp#L208