### PR TITLE
fix(account_settings): Avoid mixing up FSReadFile / FSCloseFile patches

### DIFF
--- a/src/patches/account_settings.cpp
+++ b/src/patches/account_settings.cpp
@@ -146,7 +146,7 @@ bool patchAccountSettings() {
 
     add_patch(REPLACE_FUNCTION_FOR_PROCESS(FSOpenFile_accSettings, LIBRARY_COREINIT, FSOpenFile, FP_TARGET_PROCESS_GAME), "FSOpenFile_accSettings");
     add_patch(REPLACE_FUNCTION_FOR_PROCESS(FSReadFile_accSettings, LIBRARY_COREINIT, FSReadFile, FP_TARGET_PROCESS_GAME), "FSReadFile_accSettings");
-    add_patch(REPLACE_FUNCTION_FOR_PROCESS(FSCloseFile_accSettings, LIBRARY_COREINIT, FSReadFile, FP_TARGET_PROCESS_GAME), "FSCloseFile_accSettings");
+    add_patch(REPLACE_FUNCTION_FOR_PROCESS(FSCloseFile_accSettings, LIBRARY_COREINIT, FSCloseFile, FP_TARGET_PROCESS_GAME), "FSCloseFile_accSettings");
         
     return true;
 }


### PR DESCRIPTION
### Changes:

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.

Fixes a copy-and-paste error that caused the Account Settings applet to freeze on a loading screen when launched.

Account Settings can now be accessed again. However, trying to access it a second time without rebooting still freezes the Wii U, which was another regression listed in #55.

Partially resolves #55.