### PR TITLE
Show notifcations if the plugin is missing or was (un)loaded at runtime, check title version before doing game specific patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY --from=ghcr.io/wiiu-env/libnotifications:20240426  /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libfunctionpatcher:20230621 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libkernel:20230621 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libmocha:20231127 /artifacts $DEVKITPRO
-COPY --from=ghcr.io/wiiu-env/wiiumodulesystem:0.3.3-dev-20250130-474ef70 /artifacts $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/wiiumodulesystem:20250208 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/wiiupluginsystem:20240505 /artifacts $DEVKITPRO
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY --from=ghcr.io/wiiu-env/libnotifications:20240426  /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libfunctionpatcher:20230621 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libkernel:20230621 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/libmocha:20231127 /artifacts $DEVKITPRO
-COPY --from=ghcr.io/wiiu-env/wiiumodulesystem:20240424 /artifacts $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/wiiumodulesystem:0.3.3-dev-20250130-474ef70 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/wiiupluginsystem:20240505 /artifacts $DEVKITPRO
 
 WORKDIR /app

--- a/plugin/src/config.cpp
+++ b/plugin/src/config.cpp
@@ -33,6 +33,7 @@
 #include <sysapp/title.h>
 #include <sysapp/launch.h>
 #include <nn/act.h>
+
 #include <format>
 
 static config_strings strings;

--- a/plugin/src/main.cpp
+++ b/plugin/src/main.cpp
@@ -62,7 +62,8 @@ DEINITIALIZE_PLUGIN() {
 }
 
 ON_APPLICATION_START() {
-
+    // Tell the module the plugin is running!
+    Inkay_SetPluginRunning();
 }
 
 ON_APPLICATION_ENDS() {

--- a/plugin/src/module.h
+++ b/plugin/src/module.h
@@ -27,3 +27,4 @@ enum class InkayStatus {
 void Inkay_Initialize(bool apply_patches);
 void Inkay_Finalize();
 InkayStatus Inkay_GetStatus();
+void Inkay_SetPluginRunning();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,3 +22,4 @@ bool Config::connect_to_network = false;
 bool Config::initialized = false;
 bool Config::shown_uninitialized_warning = false;
 bool Config::plugin_is_loaded = false;
+bool Config::block_initialize = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,6 +20,6 @@
 bool Config::internal_init_done = false;
 bool Config::connect_to_network = false;
 bool Config::initialized = false;
-bool Config::shown_uninitialized_warning = false;
+bool Config::shown_warning = false;
 bool Config::plugin_is_loaded = false;
 bool Config::block_initialize = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -17,7 +17,6 @@
 
 #include "config.h"
 
-bool Config::internal_init_done = false;
 bool Config::connect_to_network = false;
 bool Config::initialized = false;
 bool Config::shown_warning = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -17,6 +17,7 @@
 
 #include "config.h"
 
+bool Config::internal_init_done = false;
 bool Config::connect_to_network = false;
 bool Config::initialized = false;
 bool Config::shown_uninitialized_warning = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,3 +20,4 @@
 bool Config::connect_to_network = false;
 bool Config::initialized = false;
 bool Config::shown_uninitialized_warning = false;
+bool Config::plugin_is_loaded = false;

--- a/src/config.h
+++ b/src/config.h
@@ -15,6 +15,8 @@ public:
     static bool initialized;
 
     static bool shown_uninitialized_warning;
+
+    static bool plugin_is_loaded;
 };
 
 #endif //INKAY_CONFIG_H

--- a/src/config.h
+++ b/src/config.h
@@ -19,6 +19,8 @@ public:
     static bool shown_uninitialized_warning;
 
     static bool plugin_is_loaded;
+
+    static bool block_initialize;
 };
 
 #endif //INKAY_CONFIG_H

--- a/src/config.h
+++ b/src/config.h
@@ -16,7 +16,7 @@ public:
 
     static bool initialized;
 
-    static bool shown_uninitialized_warning;
+    static bool shown_warning;
 
     static bool plugin_is_loaded;
 

--- a/src/config.h
+++ b/src/config.h
@@ -10,6 +10,8 @@
 
 class Config {
 public:
+    static bool internal_init_done;
+
     static bool connect_to_network;
 
     static bool initialized;

--- a/src/config.h
+++ b/src/config.h
@@ -5,12 +5,8 @@
 #ifndef INKAY_CONFIG_H
 #define INKAY_CONFIG_H
 
-#include <string_view>
-#include <nn/swkbd.h>
-
 class Config {
 public:
-    static bool internal_init_done;
 
     static bool connect_to_network;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,13 +208,12 @@ WUMS_APPLICATION_STARTS() {
 }
 
 WUMS_ALL_APPLICATION_STARTS_DONE() {
-    if (!Config::internal_init_done) {
-        setup_olv_libs();
-        peertopeer_patch();
-        matchmaking_notify_titleswitch();
-        hotpatchAccountSettings();
-        Config::internal_init_done = true;
-    }
+    // we need to do the patches here because otherwise the Config::connect_to_network flag might be set yet
+    setup_olv_libs();
+    peertopeer_patch();
+    matchmaking_notify_titleswitch();
+    hotpatchAccountSettings();
+
     if (Config::initialized && !Config::plugin_is_loaded) {
         DEBUG_FUNCTION_LINE("Inkay is running but the plugin got unloaded");
         if (!Config::block_initialize) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,11 @@ static void Inkay_Initialize(bool apply_patches) {
     if (Config::initialized)
         return;
 
+    if (Config::block_initialize) {
+        ShowNotification("Failed to init Inkay. Please restart the console to use Pretendo");
+        return;
+    }
+
     // if using pretendo then (try to) apply the ssl patches
     if (apply_patches) {
         Config::connect_to_network = true;
@@ -212,12 +217,17 @@ WUMS_ALL_APPLICATION_STARTS_DONE() {
     }
     if (Config::initialized && !Config::plugin_is_loaded) {
         DEBUG_FUNCTION_LINE("Inkay is running but the plugin got unloaded");
-        ShowNotification("Inkay module is still running. Please restart the console to disable Pretendo.");
+        if (!Config::block_initialize) {
+            ShowNotification("Inkay module is still running. Please restart the console to disable Pretendo.");
+        }
         Config::shown_uninitialized_warning = true;
     } else if (!Config::initialized && !Config::shown_uninitialized_warning) {
         DEBUG_FUNCTION_LINE("Inkay module not initialized");
         ShowNotification("Inkay module was not initialized. Ensure you have the Inkay plugin loaded");
         Config::shown_uninitialized_warning = true;
+    }
+    if (!Config::initialized) {
+        Config::block_initialize = true;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,14 +200,16 @@ WUMS_APPLICATION_STARTS() {
 
     // Reset plugin loaded flag
     Config::plugin_is_loaded = false;
-
-    setup_olv_libs();
-    peertopeer_patch();
-    matchmaking_notify_titleswitch();
-    hotpatchAccountSettings();
 }
 
 WUMS_ALL_APPLICATION_STARTS_DONE() {
+    if (!Config::internal_init_done) {
+        setup_olv_libs();
+        peertopeer_patch();
+        matchmaking_notify_titleswitch();
+        hotpatchAccountSettings();
+        Config::internal_init_done = true;
+    }
     if (Config::initialized && !Config::plugin_is_loaded) {
         DEBUG_FUNCTION_LINE("Inkay is running but the plugin got unloaded");
         ShowNotification("Inkay module is still running. Please restart the console to disable Pretendo.");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,7 +127,7 @@ static void Inkay_Initialize(bool apply_patches) {
         return;
 
     if (Config::block_initialize) {
-        ShowNotification("Failed to init Inkay. Please restart the console to use Pretendo");
+        ShowNotification("Cannot load Inkay while the system is running. Please restart the console");
         return;
     }
 
@@ -218,7 +218,7 @@ WUMS_ALL_APPLICATION_STARTS_DONE() {
     if (Config::initialized && !Config::plugin_is_loaded) {
         DEBUG_FUNCTION_LINE("Inkay is running but the plugin got unloaded");
         if (!Config::block_initialize) {
-            ShowNotification("Inkay module is still running. Please restart the console to disable Pretendo.");
+            ShowNotification("Inkay module is still running. Please restart the console");
         }
         Config::shown_uninitialized_warning = true;
     } else if (!Config::initialized && !Config::shown_uninitialized_warning) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -220,11 +220,11 @@ WUMS_ALL_APPLICATION_STARTS_DONE() {
         if (!Config::block_initialize) {
             ShowNotification("Inkay module is still running. Please restart the console");
         }
-        Config::shown_uninitialized_warning = true;
-    } else if (!Config::initialized && !Config::shown_uninitialized_warning) {
+        Config::shown_warning = true;
+    } else if (!Config::initialized && !Config::shown_warning) {
         DEBUG_FUNCTION_LINE("Inkay module not initialized");
         ShowNotification("Inkay module was not initialized. Ensure you have the Inkay plugin loaded");
-        Config::shown_uninitialized_warning = true;
+        Config::shown_warning = true;
     }
     if (!Config::initialized) {
         Config::block_initialize = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,22 +16,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdio.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <wums.h>
-#include <optional>
-#include <nsysnet/nssl.h>
-#include <sysapp/title.h>
-#include <coreinit/cache.h>
-#include <coreinit/dynload.h>
-#include <coreinit/mcp.h>
-#include <coreinit/memory.h>
-#include <coreinit/memorymap.h>
-#include <coreinit/memexpheap.h>
-#include <coreinit/title.h>
-#include <notifications/notifications.h>
-#include <utils/logger.h>
 #include "export.h"
 #include "iosu_url_patches.h"
 #include "config.h"
@@ -39,15 +23,21 @@
 #include "patches/olv_urls.h"
 #include "patches/game_matchmaking.h"
 
-#include <coreinit/filesystem.h>
-#include <cstring>
+#include <wums.h>
+
+#include <coreinit/dynload.h>
+#include <coreinit/mcp.h>
+
+#include <notifications/notifications.h>
+#include <utils/logger.h>
+
 #include <string>
-#include <nn/erreula/erreula_cpp.h>
-#include <nn/act/client_cpp.h>
+#include <optional>
+
+#include <cstring>
+#include <cstdint>
 
 #include "ca_pem.h"
-
-#include <gx2/surface.h>
 
 #define INKAY_VERSION "v2.6.0"
 
@@ -67,7 +57,6 @@ WUMS_DEPENDS_ON(homebrew_notifications);
 
 WUMS_USE_WUT_DEVOPTAB();
 
-#include <kernel/kernel.h>
 #include <mocha/mocha.h>
 #include <function_patcher/function_patching.h>
 #include "patches/account_settings.h"

--- a/src/patches/account_settings.cpp
+++ b/src/patches/account_settings.cpp
@@ -24,12 +24,12 @@
 #include "inkay_config.h"
 
 #include <function_patcher/function_patching.h>
-#include <vector>
-#include <optional>
-#include <coreinit/debug.h>
+
 #include <coreinit/filesystem.h>
 #include <coreinit/title.h>
-#include <nsysnet/nssl.h>
+
+#include <vector>
+#include <optional>
 
 #include "ca_pem.h" // generated at buildtime
 
@@ -163,7 +163,7 @@ bool hotpatchAccountSettings() {
 }
 
 void unpatchAccountSettings() {
-    for (auto handle: account_patches) {
+    for (const auto handle: account_patches) {
         FunctionPatcher_RemoveFunctionPatch(handle);
     }
     account_patches.clear();

--- a/src/utils/rpl_info.h
+++ b/src/utils/rpl_info.h
@@ -26,3 +26,5 @@ constexpr void *rpl_addr(OSDynLoad_NotifyData rpl, uint32_t cemu_addr) {
         return (void *)(rpl.dataAddr + cemu_addr - 0x1000'0000);
     }
 }
+
+std::optional<uint16_t> get_current_title_version();


### PR DESCRIPTION
### Changes:

The upcoming Aroma release will allow the user to (un)load any plugin at run time via the WUPS config menu. Because of this, we could up in a scenario, where the module is loaded but the plugin is not. 

These changes will:
- Notifiy the user when unloading the plugin to let them know they need to restart the console to unload Prentendo
- Notify the user when no plugin is active/loaded at all
- Avoid an init of Inkay after boot. Currently it's not possible to start the console without the plugin and then activate (or wiiload) it in a later time to use Prentendo. I included a change to block a init for these cases.

### Note:
- These changes require some (still experimental) changes to WUMS which are not fullyreleased yet, not nightly exists
- For resting you need to use the [WUMSLoader nightly](https://github.com/wiiu-env/WUMSLoader/releases/tag/WUMSLoader-20250208-134020), [AromaBaseModule nightly](https://github.com/wiiu-env/AromaBaseModule/releases/tag/AromaBaseModule-20250208-133206) and compile these AND Inkay with [WUMS 0.3.3](https://github.com/wiiu-env/WiiUModuleSystem). Prebuilt binarys were shared on Discord.
- Translations are missing and messages for the notifcations are not final

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).