### PR TITLE
feat: make startup toast optional

### DIFF
--- a/common/lang.h
+++ b/common/lang.h
@@ -7,6 +7,7 @@ struct config_strings {
     const char *plugin_name;
     std::string_view network_category;
     std::string_view connect_to_network_setting;
+    std::string_view show_startup_toast_setting;
     std::string_view other_category;
     std::string_view reset_wwp_setting;
     std::string_view press_a_action;

--- a/plugin/src/config.cpp
+++ b/plugin/src/config.cpp
@@ -39,6 +39,7 @@
 static config_strings strings;
 
 bool Config::connect_to_network = true;
+bool Config::show_startup_toast = true;
 bool Config::need_relaunch = false;
 bool Config::unregister_task_item_pressed = false;
 bool Config::is_wiiu_menu = false;
@@ -61,6 +62,15 @@ static void connect_to_network_changed(ConfigItemBoolean* item, bool new_value) 
 
     WUPSStorageError res;
     res = WUPSStorageAPI::Store<bool>("connect_to_network", Config::connect_to_network);
+    if (res != WUPS_STORAGE_ERROR_SUCCESS) return report_storage_error(res);
+}
+
+static void show_startup_toast_changed(ConfigItemBoolean* item, bool new_value) {
+    DEBUG_FUNCTION_LINE_VERBOSE("show_startup_toast changed to: %d", new_value);
+    Config::show_startup_toast = new_value;
+
+    WUPSStorageError res;
+    res = WUPSStorageAPI::Store<bool>("show_startup_toast", Config::show_startup_toast);
     if (res != WUPS_STORAGE_ERROR_SUCCESS) return report_storage_error(res);
 }
 
@@ -156,6 +166,9 @@ static WUPSConfigAPICallbackStatus ConfigMenuOpenedCallback(WUPSConfigCategoryHa
     auto other_cat = WUPSConfigCategory::Create(strings.other_category, err);
     if (!other_cat) return report_error(err);
 
+    auto startup_toast_item = WUPSConfigItemBoolean::Create("show_startup_toast", strings.show_startup_toast_setting, true, Config::show_startup_toast, &show_startup_toast_changed, err);
+    if (!startup_toast_item) return report_error(err);
+
     WUPSConfigAPIItemCallbacksV2 unregisterTasksItemCallbacks = {
             .getCurrentValueDisplay = unregister_task_item_get_display_value,
             .getCurrentValueSelectedDisplay = unregister_task_item_get_display_value,
@@ -180,6 +193,9 @@ static WUPSConfigAPICallbackStatus ConfigMenuOpenedCallback(WUPSConfigCategoryHa
 
     err = WUPSConfigAPI_Category_AddItem(other_cat->getHandle(), unregisterTasksItem);
     if (err != WUPSCONFIG_API_RESULT_SUCCESS) return report_error(err);
+
+    res = other_cat->add(std::move(*startup_toast_item), err);
+    if (!res) return report_error(err);
 
     res = root.add(std::move(*other_cat), err);
     if (!res) return report_error(err);
@@ -210,7 +226,7 @@ void Config::Init() {
     if (cres != WUPSCONFIG_API_RESULT_SUCCESS) return (void)report_error(cres);
 
     WUPSStorageError res;
-    // Try to get value from storage
+    // Try to get values from storage
     res = WUPSStorageAPI::Get<bool>("connect_to_network", Config::connect_to_network);
     if (res == WUPS_STORAGE_ERROR_NOT_FOUND) {
         DEBUG_FUNCTION_LINE("Connect to network value not found, attempting to migrate/create");
@@ -224,6 +240,16 @@ void Config::Init() {
     
         // Add the value to the storage if it's missing.
         res = WUPSStorageAPI::Store<bool>("connect_to_network", connect_to_network);
+        if (res != WUPS_STORAGE_ERROR_SUCCESS) return report_storage_error(res);
+    }
+    else if (res != WUPS_STORAGE_ERROR_SUCCESS) return report_storage_error(res);
+
+    res = WUPSStorageAPI::Get<bool>("show_startup_toast", Config::show_startup_toast);
+    if (res == WUPS_STORAGE_ERROR_NOT_FOUND) {
+        DEBUG_FUNCTION_LINE("Show startup toast value not found, attempting to create");
+    
+        // Add the value to the storage if it's missing.
+        res = WUPSStorageAPI::Store<bool>("show_startup_toast", show_startup_toast);
         if (res != WUPS_STORAGE_ERROR_SUCCESS) return report_storage_error(res);
     }
     else if (res != WUPS_STORAGE_ERROR_SUCCESS) return report_storage_error(res);

--- a/plugin/src/config.h
+++ b/plugin/src/config.h
@@ -12,6 +12,8 @@ public:
     // wups config items
     static bool connect_to_network;
 
+    static bool show_startup_toast;
+
     // private stuff
     static bool need_relaunch;
 

--- a/plugin/src/main.cpp
+++ b/plugin/src/main.cpp
@@ -50,7 +50,7 @@ INITIALIZE_PLUGIN() {
     }
 
     // if using pretendo then (try to) apply the ssl patches
-    Inkay_Initialize(Config::connect_to_network);
+    Inkay_Initialize(Config::connect_to_network, Config::show_startup_toast);
 }
 
 DEINITIALIZE_PLUGIN() {

--- a/plugin/src/module.cpp
+++ b/plugin/src/module.cpp
@@ -24,7 +24,7 @@
 #include <coreinit/dynload.h>
 
 static OSDynLoad_Module module;
-static void (*moduleInitialize)(bool) = nullptr;
+static void (*moduleInitialize)(bool, bool) = nullptr;
 static InkayStatus (*moduleGetStatus)() = nullptr;
 static void (*moduleSetPluginRunning)() = nullptr;
 
@@ -36,7 +36,7 @@ static const char *get_module_init_not_found_message() {
     return get_config_strings(get_system_language()).module_init_not_found.data();
 }
 
-void Inkay_Initialize(bool apply_patches) {
+void Inkay_Initialize(bool apply_patches, bool show_startup_toast) {
     if (module) {
         return;
     }
@@ -54,7 +54,7 @@ void Inkay_Initialize(bool apply_patches) {
         return;
     }
 
-    moduleInitialize(apply_patches);
+    moduleInitialize(apply_patches, show_startup_toast);
 }
 
 void Inkay_Finalize() {

--- a/plugin/src/module.h
+++ b/plugin/src/module.h
@@ -24,7 +24,7 @@ enum class InkayStatus {
     Error = -1     ///< Failed to retrieve the module status
 };
 
-void Inkay_Initialize(bool apply_patches);
+void Inkay_Initialize(bool apply_patches, bool show_startup_toast);
 void Inkay_Finalize();
 InkayStatus Inkay_GetStatus();
 void Inkay_SetPluginRunning();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -18,6 +18,7 @@
 #include "config.h"
 
 bool Config::connect_to_network = false;
+bool Config::show_startup_toast = false;
 bool Config::initialized = false;
 bool Config::shown_warning = false;
 bool Config::plugin_is_loaded = false;

--- a/src/config.h
+++ b/src/config.h
@@ -10,6 +10,8 @@ public:
 
     static bool connect_to_network;
 
+    static bool show_startup_toast;
+
     static bool initialized;
 
     static bool shown_warning;

--- a/src/lang/en_US.lang
+++ b/src/lang/en_US.lang
@@ -1,6 +1,7 @@
 .plugin_name="Inkay"
 ,.network_category="Network selection"
 ,.connect_to_network_setting="Connect to Pretendo Network"
+,.show_startup_toast_setting="Show startup toast"
 ,.other_category="Other settings"
 ,.reset_wwp_setting="Reset Wara Wara Plaza"
 ,.press_a_action="Press A"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,9 +122,11 @@ static InkayStatus Inkay_GetStatus() {
     }
 }
 
-static void Inkay_Initialize(bool apply_patches) {
+static void Inkay_Initialize(bool apply_patches, bool show_startup_toast) {
     if (Config::initialized)
         return;
+
+    Config::show_startup_toast = show_startup_toast;
 
     if (Config::block_initialize) {
         ShowNotification("Cannot load Inkay while the system is running. Please restart the console");
@@ -150,12 +152,16 @@ static void Inkay_Initialize(bool apply_patches) {
 
         DEBUG_FUNCTION_LINE_VERBOSE("Pretendo URL and NoSSL patches applied successfully.");
 
-        ShowNotification(get_pretendo_message());
+        if (Config::show_startup_toast) {
+            ShowNotification(get_pretendo_message());
+        }
         Config::initialized = true;
     } else {
         DEBUG_FUNCTION_LINE_VERBOSE("Pretendo URL and NoSSL patches skipped.");
 
-        ShowNotification(get_nintendo_network_message());
+        if(Config::show_startup_toast) {
+            ShowNotification(get_nintendo_network_message());
+        }
         Config::initialized = true;
         return;
     }


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #75 

### Changes:
Added a new configuration option (enabled by default) that will show or hide the "Using Pretendo/Nintendo network" startup message. 
Updated `en_US.lang`, other language files will need this line translated. 
<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.